### PR TITLE
Update Kubernetes version to 1.19.9

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ to modify the playbook to accommodate your own environment.
 |  org                   | IBM Cloud organization | string  |  ✓ |  |  |
 |  space                 | The space in IBM Cloud | string  | ✓ |  |  |
 |  resource_group        | The resource group in IBM Cloud | string  |  | default |  |
-|  kube_version          | kubernetes version | string  |  | 1.18.16 |  |
+|  kube_version          | kubernetes version | string  |  | 1.19.9 |  |
 |  appid_plan            | The plan for AppID | string  |  | lite |  |
 |  appid_name            | Instnace name for AppID service | string  |   | appid-instance |  |
 |  cluster_name          | Cluster name | string  |   | my-kfp-cluster | |

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -20,7 +20,7 @@ to modify the playbook to accommodate your own environment.
 |  org                   | IBM Cloud organization | string  |  ✓ |  |  |
 |  space                 | The space in IBM Cloud | string  | ✓ |  |  |
 |  resource_group        | The resource group in IBM Cloud | string  |  | default |  |
-|  kube_version          | kubernetes version | string  |  | 1.18.16 |  |
+|  kube_version          | kubernetes version | string  |  | 1.19.9 |  |
 |  appid_plan            | The plan for AppID | string  |  | lite |  |
 |  appid_name            | Instnace name for AppID service | string  |   | appid-instance |  |
 |  cluster_name          | Cluster name | string  |   | my-kfp-cluster | |

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -18,7 +18,7 @@ variable space {
 
 variable kube_version {
   type        = string
-  default     = "1.18.16"
+  default     = "1.19.9"
   description = "kubectl version"
 }
 

--- a/terraform/vpc-gen2-cluster/variables.tf
+++ b/terraform/vpc-gen2-cluster/variables.tf
@@ -34,7 +34,7 @@ variable "cluster_name" {
 }
 
 variable "kube_version" {
-  default     = "1.18.6"
+  default     = "1.19.9"
   type        = string
   description = "kubernetes version"
 }


### PR DESCRIPTION
Update default Kubernetes version to 1.19.9 to align with the default
in the IBM Cloud which was changed to 1.19.9

Signed-off-by: Chin Huang <chhuang@us.ibm.com>